### PR TITLE
Add privileges to codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,9 @@
 
 name: "CodeQL"
 
+permissions:
+  security-events: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Explicitly give codeql-analysis action the security-events: write permission so it still works even when the default GitHub Actions token is set to read-only.