### PR TITLE
Dedupe types requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.11
 
 ENV PYTHONUNBUFFERED 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.9
 
 ENV PYTHONUNBUFFERED 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ django-sass-processor==1.2.2
 django-csp==3.7
 environs==9.5.0
 flower==1.2.0
+grpcio==1.57.0
 libsass==0.22.0
 Markdown==3.4.1
 Pillow==9.4.0
@@ -35,6 +36,7 @@ opentelemetry-sdk==1.16.0
 protobuf==3.20.*
 pyotp==2.8.0
 qrcode==7.3.1
+tornado==6.3.3
 
 # Dev
 pytest-django==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ django-sass-processor==1.2.2
 django-csp==3.7
 environs==9.5.0
 flower==1.2.0
-grpcio==1.57.0
 libsass==0.22.0
 Markdown==3.4.1
 Pillow==9.4.0
@@ -35,7 +34,6 @@ opentelemetry-sdk==1.16.0
 protobuf==3.20.*
 pyotp==2.8.0
 qrcode==7.3.1
-tornado==6.3.3
 
 # Dev
 pytest-django==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp==3.9.2
 bleach==5.0.1
+bw-file-resubmit==0.6.0rc2
 celery==5.3.1
 colorthief==0.2.1
 Django==3.2.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ tornado==6.3.3
 
 # Dev
 pytest-django==4.1.0
-pytest==6.2.5
+pytest==6.1.2
 pytest-cov==2.10.1
 pytest-env==0.6.2
 pytest-xdist==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,4 +56,3 @@ types-Pillow==10.0.0.3
 types-psycopg2==2.9.21.11
 types-python-dateutil==2.8.19.14
 types-requests==2.31.0.2
-types-requests==2.31.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ tornado==6.3.3
 
 # Dev
 pytest-django==4.1.0
-pytest==6.1.2
+pytest==6.2.5
 pytest-cov==2.10.1
 pytest-env==0.6.2
 pytest-xdist==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.9.2
 bleach==5.0.1
 celery==5.3.1
 colorthief==0.2.1
-Django==3.2.20
+Django==3.2.24
 django-celery-beat==2.4.0
 django-compressor==4.3.1
 django-imagekit==4.1.0


### PR DESCRIPTION
We currently call for an identical version of types-requests twice at the very end of requirements.txt. This removes one of those lines.