### PR TITLE
Improve password validation

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -295,6 +295,9 @@ AUTH_USER_MODEL = "bookwyrm.User"
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        'OPTIONS': {
+            'max_similarity': .9,
+        }
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -298,6 +298,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        'OPTIONS': {
+            'min_length': 16,
+        }
     },
     {
         "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",

--- a/bookwyrm/views/landing/password.py
+++ b/bookwyrm/views/landing/password.py
@@ -75,6 +75,7 @@ class PasswordReset(View):
             return TemplateResponse(request, "landing/password_reset.html", data)
 
         new_password = form.cleaned_data["password"]
+        # deepcode ignore DjangoUnvalidatedPassword: cleaned_data validates the password; would be nice to move validation here eventually
         user.set_password(new_password)
         user.save(broadcast=False, update_fields=["password"])
         login(request, user)

--- a/bookwyrm/views/preferences/change_password.py
+++ b/bookwyrm/views/preferences/change_password.py
@@ -30,7 +30,8 @@ class ChangePassword(View):
             data = {"form": form}
             return TemplateResponse(request, "preferences/change_password.html", data)
 
-        new_password = form.cleaned_data["password"]
+        new_password = form.cleaned_data["password"] 
+        # deepcode ignore DjangoUnvalidatedPassword: cleaned_data includes password validation; would be nice to move it here eventually
         request.user.set_password(new_password)
         request.user.save(broadcast=False, update_fields=["password"])
 


### PR DESCRIPTION
This PR proposes a minimum password length of 16 (up from the Django default of 8) and similarity requirement of .9 (very slightly stricter than the default requirement of 1, which is basically just "it is not literally your username or email"). I've proposed it for merge to production in alignment with our current deployment process, because we do not intend to propose these tighter requirements upstream.

When this is merged, we should post an admin announcement to warn our users before we deploy in case it confuses anyone (though I don't think any of our existing users would've set a password that doesn't comply with the requirements, since we currently know them all personally). 